### PR TITLE
Fix LoggerAwareInterface

### DIFF
--- a/src/SysAdapter.php
+++ b/src/SysAdapter.php
@@ -42,7 +42,7 @@ class SysAdapter implements Adapter, LoggerAwareInterface
 	 *
 	 * @return void
 	 */
-	public function setLogger(LoggerInterface $logger)
+	public function setLogger(LoggerInterface $logger): void
 	{
 		$this->logger = $logger;
 	}


### PR DESCRIPTION
Declaration of 
`Nextcloud\\KItinerary\\Sys\\SysAdapter::setLogger(Psr\\Log\\LoggerInterface $logger)`
must be compatible with
`Psr\\Log\\LoggerAwareInterface::setLogger(Psr\\Log\\LoggerInterface $logger): void`